### PR TITLE
remove suppression of error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -276,9 +276,6 @@ MqttClient.prototype._setupStream = function () {
 
   this.stream.pipe(writable)
 
-  // Suppress connection errors
-  this.stream.on('error', nop)
-
   // Echo stream close
   eos(this.stream, this.emit.bind(this, 'close'))
 


### PR DESCRIPTION
allow the client to handle the error in the error callback. this fixes an issue where the mqtt.js client infintely reconnects if a bad username or password is presented. This can also occur if the client needs to reconnect after a reboot and its current credentials are invalid